### PR TITLE
Remove splitting command line

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -98,23 +98,15 @@ export async function readDependencies(
           std_err += data.toString()
         }
       }
-      options.cwd = '././'
 
-      const manifestCmdArr = manifestInfo.command.split(' ')
-      return exec
-        .exec(
-          manifestCmdArr[0],
-          manifestCmdArr.slice(1, manifestCmdArr.length),
-          options
-        )
-        .then((res) => {
-          if (std_err) {
-            console.log(std_err)
-          }
+      return exec.exec(manifestInfo.command, undefined, options).then((res) => {
+        if (std_err) {
+          console.log(std_err)
+        }
 
-          const entries = dependenciesProcessorFunc(output)
-          return entries
-        })
+        const entries = dependenciesProcessorFunc(output)
+        return entries
+      })
     }
   } catch (error) {
     if (error instanceof Error) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "compilerOptions": {
-    "declaration": true, /* Generate .d.ts files */
     "target": "es6", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "outDir": "./dist", /* Redirect output structure to the directory. */
     "rootDir": "./src", /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     "strict": true, /* Enable all strict type-checking options. */
     "noImplicitAny": true, /* Raise error on expressions and declarations with an implied 'any' type. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
When a command requires an argument that is a quoted-string with spaces, the current code will incorrectly split quoted arguments into multiple arguments. The `@action/exec` library implements command+argument splitting in a way that handles quotes ([source](https://github.com/actions/toolkit/blob/500d0b42fee2552ae9eeb5933091fe2fbf14e72d/packages/exec/src/toolrunner.ts#L560-L615)). This removes our current splitting and allows us to use `@action/exec`'s implementation.