### PR TITLE
Illustrating a separation between graph and lib consumer

### DIFF
--- a/example/npm-detector.test.ts
+++ b/example/npm-detector.test.ts
@@ -1,7 +1,6 @@
 import {
   parseNameAndNamespace,
-  parseDependencies,
-  createBuildTarget
+  getManifest
 } from './npm-detector'
 
 import { Graph } from '@github/dependency-submission-toolkit'
@@ -32,42 +31,42 @@ describe('parseNameAndNamespace', () => {
   })
 })
 
-describe('parseDependencies', () => {
-  test('parse single dependency', () => {
-    const dependencies = { foo: { version: '1.0' } }
-    const graph = new Graph()
-    const pkgs = parseDependencies(graph, dependencies)
+// describe('parseDependencies', () => {
+//   test('parse single dependency', () => {
+//     const dependencies = { foo: { version: '1.0' } }
+//     const graph = new Graph()
+//     const pkgs = parseDependencies(graph, dependencies)
 
-    expect(pkgs).toHaveLength(1)
-    expect(pkgs[0].packageID()).toEqual('pkg:npm/foo@1.0')
-    expect(graph.countPackages()).toEqual(1)
-  })
+//     expect(pkgs).toHaveLength(1)
+//     expect(pkgs[0].packageID()).toEqual('pkg:npm/foo@1.0')
+//     expect(graph.countPackages()).toEqual(1)
+//   })
 
-  test('parse multiple dependencies, single depth', () => {
-    const dependencies = { foo: { version: '1.0' }, bar: { version: '2.0' } }
-    const graph = new Graph()
-    const pkgs = parseDependencies(graph, dependencies)
+//   test('parse multiple dependencies, single depth', () => {
+//     const dependencies = { foo: { version: '1.0' }, bar: { version: '2.0' } }
+//     const graph = new Graph()
+//     const pkgs = parseDependencies(graph, dependencies)
 
-    expect(pkgs).toHaveLength(2)
-    expect(pkgs[0].packageID()).toEqual('pkg:npm/foo@1.0')
-    expect(pkgs[1].packageID()).toEqual('pkg:npm/bar@2.0')
-    expect(graph.countPackages()).toEqual(2)
-  })
+//     expect(pkgs).toHaveLength(2)
+//     expect(pkgs[0].packageID()).toEqual('pkg:npm/foo@1.0')
+//     expect(pkgs[1].packageID()).toEqual('pkg:npm/bar@2.0')
+//     expect(graph.countPackages()).toEqual(2)
+//   })
 
-  test('parse multiple depth', () => {
-    const dependencies = {
-      foo: { version: '1.0', dependencies: { bar: { version: '2.0' } } }
-    }
-    const graph = new Graph()
-    const pkgs = parseDependencies(graph, dependencies)
+//   test('parse multiple depth', () => {
+//     const dependencies = {
+//       foo: { version: '1.0', dependencies: { bar: { version: '2.0' } } }
+//     }
+//     const graph = new Graph()
+//     const pkgs = parseDependencies(graph, dependencies)
 
-    expect(pkgs).toHaveLength(1)
-    expect(pkgs[0].packageID()).toEqual('pkg:npm/foo@1.0')
-    expect(pkgs[0].transitiveIDs).toHaveLength(1)
-    expect(pkgs[0].transitiveIDs[0]).toEqual('pkg:npm/bar@2.0')
-    expect(graph.countPackages()).toEqual(2)
-  })
-})
+//     expect(pkgs).toHaveLength(1)
+//     expect(pkgs[0].packageID()).toEqual('pkg:npm/foo@1.0')
+//     expect(pkgs[0].transitiveIDs).toHaveLength(1)
+//     expect(pkgs[0].transitiveIDs[0]).toEqual('pkg:npm/bar@2.0')
+//     expect(graph.countPackages()).toEqual(2)
+//   })
+// })
 
 describe('createBuildTarget', () => {
   test('parse npm package', () => {
@@ -80,7 +79,7 @@ describe('createBuildTarget', () => {
       }
     }
 
-    const buildTarget = createBuildTarget(npmPackage)
+    const buildTarget = getManifest(npmPackage)
     expect(buildTarget.name).toEqual('example-package')
     expect(buildTarget.directDependencies()).toHaveLength(2)
     expect(buildTarget.indirectDependencies()).toHaveLength(1)

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -80,6 +80,10 @@ export class Graph {
     return this.lookupPackage(identifier) !== undefined
   }
 
+  packages(): Package[] {
+    return Object.values(this.database)
+  }
+
   /**
    * countPackages returns the total number of packages tracked in the graph
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,17 @@
 import { Graph } from './graph'
-import { Manifest, BuildTarget } from './manifest'
+import { Manifest } from './manifest'
 import { Metadata } from './metadata'
 import { Package } from './package'
 import { Snapshot, submitSnapshot } from './snapshot'
+import { Recorder, ManifestRecorder } from './recorder'
 
 export {
-  BuildTarget,
   Manifest,
   Graph,
   Metadata,
   Package,
+  Recorder,
+  ManifestRecorder,
   Snapshot,
   submitSnapshot
 }

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -160,26 +160,3 @@ export class Manifest {
   }
 }
 
-/**
- * The dependencies used in a code artifact or "build target" are more
- * accurately determined by the build process or commands used to generate the
- * build target, rather than static processing of package files. BuildTarget is
- * a specialized case of Manifest intended to assist in capturing this
- * association of build target and dependencies.
- *
- * @extends {Manifest}
- */
-export class BuildTarget extends Manifest {
-  /**
-   * addBuildDependency will add a package as a direct runtime dependency and all of
-   * the packages transitive dependencies as indirect dependencies
-   *
-   * @param {Package} pkg package used to build the build target
-   */
-  addBuildDependency(pkg: Package) {
-    this.addDirectDependency(pkg, 'runtime')
-    pkg.transitiveDependencies.forEach((transDep) => {
-      this.addIndirectDependency(transDep, 'runtime')
-    })
-  }
-}

--- a/src/package.ts
+++ b/src/package.ts
@@ -1,4 +1,5 @@
 import { PackageURL } from 'packageurl-js'
+import { UsageInformation } from './recorder'
 
 /**
  * Package is module that can be depended upon in manifest or build target. A
@@ -83,5 +84,18 @@ export class Package {
    */
   version(): string {
     return this.packageURL.version || ''
+  }
+
+  private usageInformations: UsageInformation[] = []
+  addUsageInformation(usageInformation: UsageInformation) {
+    this.usageInformations.push(usageInformation)
+  }
+
+  isDevDependency(): boolean {
+    return this.usageInformations.map(x => x.isDevDependency).reduce((prev, current) => prev && current, true)
+  }
+
+  isDirectDependency() {
+    return this.usageInformations.map(x => x.isDirectDependency).reduce((prev, current) => prev || current, false)
   }
 }

--- a/src/recorder.ts
+++ b/src/recorder.ts
@@ -1,0 +1,90 @@
+import { PackageURL } from 'packageurl-js'
+import { Package } from './package'
+import { Graph } from './graph'
+import { Manifest } from './manifest'
+import { Metadata } from './metadata'
+
+export class UsageInformation {
+  public constructor(init?:Partial<UsageInformation>) {
+    Object.assign(this, init);
+  }
+
+  public isDevDependency: boolean = false
+  public isDirectDependency: boolean = false
+  public parentIdentifier: PackageURL | string | null = null
+}
+
+/**
+ * Use recorder to record all dependency usages
+ */
+export class Recorder {
+  private recorders: { [manifestName: string]: ManifestRecorder } = {}
+
+  public createOrGetManifestRecorder(name: string, filePath: string | undefined, metadata: Metadata): ManifestRecorder {
+    let recorder = this.recorders[name]
+    if (!recorder) {
+      let graph = new Graph()
+      recorder = new ManifestRecorder(name, filePath, metadata, graph)
+      this.recorders[name] = recorder
+    }
+
+    return recorder
+  }
+
+  public manifests(): { [manifestName: string]: Manifest } {
+    let mappedEntries = Object.values(this.recorders)
+      .map(manifestRecorder => {
+        let manifest = manifestRecorder.manifest
+        return [manifestRecorder.name, manifest]
+      })
+    return Object.fromEntries(mappedEntries)
+  }
+
+  /**
+   * We apply usage information to a given package, which is a way for us to add graph relationships and then aggregate details which may later be converted / calculated.
+   */
+}
+
+export class ManifestRecorder {
+  readonly name : string
+  readonly filePath : string | undefined
+  readonly metadata: Metadata
+  readonly graph : Graph
+
+  constructor(name: string, filePath: string | undefined, metadata: Metadata, graph: Graph) {
+    this.name = name
+    this.filePath = filePath
+    this.metadata = metadata
+    this.graph = graph
+  }
+
+  public registerUsage(identifier: PackageURL | string, usageInformation: UsageInformation = new UsageInformation()): Package {
+    const dep = this.graph.package(identifier)
+    this.applyUsageInformation(this.graph, dep, usageInformation)
+    return dep
+  }
+
+  public manifest(): Manifest {
+    let manifest = new Manifest(this.name, this.filePath, this.metadata)
+    this.graph.packages().forEach(p => {
+      if (p.isDirectDependency()) {
+        manifest.addDirectDependency(p, p.isDevDependency() ? 'development' : 'runtime')
+      } else {
+        manifest.addIndirectDependency(p, p.isDevDependency() ? 'development' : 'runtime')
+      }
+    })
+
+    return manifest
+  }
+
+  private applyUsageInformation(graph: Graph, dep: Package, usageInformation: UsageInformation) {
+    if (usageInformation.parentIdentifier != null) {
+      let parentPackage = graph.package(usageInformation.parentIdentifier)
+      parentPackage.addTransitive(dep)
+    }
+
+    dep.addUsageInformation(usageInformation);
+  }
+}
+
+


### PR DESCRIPTION
I expect the example we're using really only needs `ManifestRecorder`, not `Recorder`.  The goal of this is to show that we really don't need to have customers manage transitives etc, just register a usage, and we can make translation decisions and data aggregation decisions later. 