### PR TITLE
Adding write permissions to the example Action

### DIFF
--- a/.github/workflows/dependency-submission-example.yml
+++ b/.github/workflows/dependency-submission-example.yml
@@ -1,6 +1,10 @@
 name: Example Dependency Submission
 on:
   push
+
+permissions:
+  contents: write
+
 jobs:
   example-submission:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds write permissions to the example Action, following the guidelines in the [submission API](https://github.com/actions/go-dependency-submission#example) examples.