### PR TITLE
Fix possible exceptions by matching the type of Snapshot job to the spec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7227,7 +7227,7 @@
     "@github/dependency-submission-toolkit": {
       "version": "file:",
       "requires": {
-        "@actions/core": "1.9.1",
+        "@actions/core": "^1.6.0",
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.0.0",
         "@octokit/rest": "^18.12.0",

--- a/src/snapshot.test.ts
+++ b/src/snapshot.test.ts
@@ -32,7 +32,7 @@ describe('Snapshot', () => {
         version: '0.0.1'
       },
       context,
-      { id: 42, correlator: 'test' },
+      { id: '42', correlator: 'test' },
       new Date('2022-06-04T05:07:06.457Z')
     )
     snapshot.addManifest(manifest)
@@ -44,7 +44,7 @@ describe('Snapshot', () => {
       },
       version: 0,
       job: {
-        id: 42,
+        id: '42',
         correlator: 'test'
       },
       ref: 'foo/bar/baz',

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -16,7 +16,7 @@ Core functionality for creating a snapshot of a project's dependencies.
  */
 export type Job = {
   correlator: string
-  id: string | number
+  id: string
   html_url?: string // eslint-disable-line camelcase
 }
 


### PR DESCRIPTION
https://docs.github.com/en/rest/dependency-graph/dependency-submission#create-a-snapshot-of-dependencies-for-a-repository

```
Error: HTTP Status 422 for request POST https://api.github.com/repos/smorimoto/opam-dependency-submission/dependency-graph/snapshots
Error: Response body:
{
  "message": "Invalid request.\n\nInvalid property /job/id: `3116879171` is not of type `string`.",
  "documentation_url": "https://docs.github.com/rest/reference/dependency-graph#create-a-snapshot-of-dependencies-for-a-repository"
}
Error: Invalid request.
```