### PR TITLE
Use github.getOctokit

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -145,9 +145,7 @@ export async function submitSnapshot(
 
   const repo = context.repo
   const githubToken = core.getInput('token') || (await core.getIDToken())
-  const octokit = new Octokit({
-    auth: githubToken
-  })
+  const octokit = github.getOctokit(githubToken)
 
   try {
     const response = await octokit.request(


### PR DESCRIPTION
I think we should use `github.getOctokit` instead of `new Octokit` to obtain an Octokit instance that works well with GitHub Enterprise.

See also: https://github.com/actions/toolkit/tree/main/packages/github#readme