### PR TITLE
Adding a contributor's guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,20 +60,6 @@ Here are a few things you can do that will increase the likelihood of your pull 
    include a small description of the biggest changes in the new version.
 6. Click "Publish Release".
 
-You now have a tag and release using the semver version you used
-above. The last remaining thing to do is to move the dynamic version
-identifier to match the current SHA. This allows users to adopt a
-major version number (e.g. `v1`) in their workflows while
-automatically getting all the
-minor/patch updates.
-
-To do this just checkout `main`, force-create a new annotated tag, and push it:
-
-```
-git tag -fa v2 -m "Updating v2 to 2.3.4"
-git push origin v2 --force
-```
-
 ## Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,81 @@
+# Contributing
+
+[fork]: https://github.com/github/dependency-submission-toolkit/fork
+[pr]: https://github.com/github/dependency-submission-toolkit/compare
+[code-of-conduct]: CODE_OF_CONDUCT.md
+
+Hi there! We're thrilled that you'd like to contribute to this project. Your help is essential for keeping it great.
+
+Contributions to this project are
+[released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license)
+to the public under the [project's open source license](LICENSE).
+
+Please note that this project is released with a [Contributor Code of
+Conduct][code-of-conduct]. By participating in this project you agree
+to abide by its terms.
+
+### Bootstrapping the project
+
+```
+git clone https://github.com/github/dependency-submission-toolkit.git
+cd dependency-submission-toolkit
+npm install
+```
+
+### Running the tests
+
+```
+npm run test
+```
+
+## Submitting a pull request
+
+0. [Fork][fork] and clone the repository
+1. Configure and install the dependencies: `npm install`
+2. Make sure the tests pass on your machine: `npm run test`
+3. Create a new branch: `git checkout -b my-branch-name`
+4. Make your change, add tests, and make sure the tests still pass
+5. Make sure to build and package before pushing: `npm run all`
+6. Push to your fork and [submit a pull request][pr]
+7. Pat your self on the back and wait for your pull request to be reviewed and merged.
+
+Here are a few things you can do that will increase the likelihood of your pull request being accepted:
+
+- Write tests.
+- Keep your change as focused as possible. If there are multiple changes you would like to make that are not dependent upon each other, consider submitting them as separate pull requests.
+- Write a [good commit message](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
+
+## Cutting a new release
+
+1. Update the version number in [package.json](https://github.com/github/dependency-submission-toolkit/blob/main/package.json).
+1. Go to [Draft a new
+   release](https://github.com/github/dependency-submission-toolkit/releases/new)
+   in the Releases page.
+1. Make sure that the `Publish this Action to the GitHub Marketplace`
+   checkbox is enabled
+3. Click "Choose a tag" and then "Create new tag", where the tag name
+   will be your version prefixed by a `v` (e.g. `v1.2.3`).
+4. Use a version number for the release title (e.g. "v1.2.3").
+5. Add your release notes. If this is a major version make sure to
+   include a small description of the biggest changes in the new version.
+6. Click "Publish Release".
+
+You now have a tag and release using the semver version you used
+above. The last remaining thing to do is to move the dynamic version
+identifier to match the current SHA. This allows users to adopt a
+major version number (e.g. `v1`) in their workflows while
+automatically getting all the
+minor/patch updates.
+
+To do this just checkout `main`, force-create a new annotated tag, and push it:
+
+```
+git tag -fa v2 -m "Updating v2 to 2.3.4"
+git push origin v2 --force
+```
+
+## Resources
+
+- [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
+- [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [GitHub Help](https://help.github.com)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/dependency-submission-toolkit",
-  "version": "1.2.4",
+  "version": "1.2.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/dependency-submission-toolkit",
-      "version": "1.2.4",
+      "version": "1.2.7",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/dependency-submission-toolkit",
-  "version": "1.2.4",
+  "version": "1.2.7",
   "description": "A TypeScript library for creating dependency snapshots.",
   "prepare": "npm run build",
   "main": "dist/index.js",


### PR DESCRIPTION
Adding a `CONTRIBUTING.md` outlining the basic steps to run tests and do local development. It also includes instructions on how to release a new version, which could be helpful for other folks getting involved with the project.

This document was copy/pasted from another project and needs to be tweaked/improved for this specific tool, but I feel it's better than nothing.

### TODO
- [x] Cut a new version (1.2.7). The PR also includes a bump to the action's version and should be followed by a new release, `1.2.6` did not update the version field in `package.json`.