### PR TITLE
Update `@actions/core` to fix deprecated `set-output` usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "example"
       ],
       "dependencies": {
-        "@actions/core": "^1.6.0",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.0.0",
         "@octokit/rest": "^18.12.0",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
@@ -6679,9 +6679,9 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
@@ -7227,7 +7227,7 @@
     "@github/dependency-submission-toolkit": {
       "version": "file:",
       "requires": {
-        "@actions/core": "^1.6.0",
+        "@actions/core": "^1.10.0",
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.0.0",
         "@octokit/rest": "^18.12.0",
@@ -7255,9 +7255,9 @@
       },
       "dependencies": {
         "@actions/core": {
-          "version": "1.9.1",
-          "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-          "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+          "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
           "requires": {
             "@actions/http-client": "^2.0.1",
             "uuid": "^8.3.2"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/github/dependency-submission-toolkit#readme",
   "dependencies": {
-    "@actions/core": "^1.6.0",
+    "@actions/core": "^1.10.0",
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.0",
     "@octokit/rest": "^18.12.0",


### PR DESCRIPTION
Update `@actions/core` to v1.10.0 to replace the deprecated `set-output` method call

Find more details here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

---

This will resolve the deprecation warning being logged via the following `setOutput` API call: https://github.com/github/dependency-submission-toolkit/blob/main/src/snapshot.ts#L142