### PR TITLE
Get the right SHA for the snapshot depending on the event type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.0.0",
         "@octokit/rest": "^18.12.0",
+        "@octokit/webhooks-types": "^6.10.0",
         "openapi-typescript": "^5.2.0",
         "packageurl-js": "0.0.6"
       },
@@ -1313,6 +1314,11 @@
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
       }
+    },
+    "node_modules/@octokit/webhooks-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-6.10.0.tgz",
+      "integrity": "sha512-lDNv83BeEyxxukdQ0UttiUXawk9+6DkdjjFtm2GFED+24IQhTVaoSbwV9vWWKONyGLzRmCQqZmoEWkDhkEmPlw=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.6",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.0",
     "@octokit/rest": "^18.12.0",
+    "@octokit/webhooks-types": "^6.10.0",
     "openapi-typescript": "^5.2.0",
     "packageurl-js": "0.0.6"
   },

--- a/src/snapshot.test.ts
+++ b/src/snapshot.test.ts
@@ -22,6 +22,7 @@ manifest.addIndirectDependency(cache.package('pkg:npm/%40actions/core@1.6.0'))
 // add bogus git data to the context
 context.sha = '1000000000000000000000000000000000000000'
 context.ref = 'foo/bar/baz'
+context.eventName = 'push'
 
 describe('Snapshot', () => {
   it('renders expected JSON', () => {


### PR DESCRIPTION
As noted in [the Actions docs](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request), `context.sha` can represent different things in different event types. In a `pull_request` event, it happens _not_ to be the sha of the head commit for some reason. Instead, in those cases you're meant to get the head sha from the pull_request payload.

This PR introduces a helper function, `shaFromContext`, that matches on the event type and gets the correct sha for the snapshot. I've also taken the liberty of doing a few quick test refactors.

For prior art, see:
* [similar code in the DR action](https://github.com/actions/dependency-review-action/blob/e3fb5152be474702523c77d8f5ecd4c0a5bde872/src/git-refs.ts#L10-L19)
* [my PR for anchore/sbom-action](https://github.com/anchore/sbom-action/pull/401)