### PR TITLE
Drop ops_slack from ownership.yaml

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -16,7 +16,6 @@ ownership:
     exec_sponsor: jacobdepriest
     product_manager: courtneycl
     team_slack: dependency-graph
-    ops_slack: dg-alerts
     qos: experimental
     tier: 3
     sev1:


### PR DESCRIPTION
The field is deprecated, and you have a slack setting for your sev3
alerts which will be used.
