### PR TITLE
Update package.json to 2.0.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/dependency-submission-toolkit",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/dependency-submission-toolkit",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/dependency-submission-toolkit",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A TypeScript library for creating dependency snapshots.",
   "homepage": "https://github.com/github/dependency-submission-toolkit",
   "bugs": {


### PR DESCRIPTION
483d316 introduced a fix for a low sev vulnerability in `undici`. This PR bumps the version number in `package.json` so we can publish a new release.