### PR TITLE
Update exec sponsor to @nerdneha

### DIFF
--- a/ownership.yaml
+++ b/ownership.yaml
@@ -8,7 +8,7 @@ ownership:
     long_name: dependency-submission-toolkit
     description: 'A TypeScript library for creating dependency snapshots and submitting them to the dependency submission API.'
     maintainer: aaroncathcart
-    exec_sponsor: aaroncathcart
+    exec_sponsor: nerdneha
     product_manager: jonjanego
     team_slack: dependency-graph
     qos: experimental


### PR DESCRIPTION
Update the executive sponsor to `@nerdneha`. Sorry for the churn. We are aligning with best practice and setting the sponsor to be a VP. :bow: