### PR TITLE
Add npm to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
## Purpose

Currently Dependabot provides security checks for npm ecosystem, but it's not explicitly enabled, causing confusion in the security alerts page.

## Related Issues
E.g. [this alert](https://github.com/github/dependency-submission-toolkit/security/dependabot/42) currently looks like this:
<img width="909" alt="Screenshot 2025-03-11 at 12 33 31" src="https://github.com/user-attachments/assets/b9d67055-61b5-4461-98b0-d639aec12db0" />

The idea is that configuring Dependabot to explicitly support npm ecosystem would fix this and similar issues going forward.
