### PR TITLE
Explicitly override @octokit/request-error to a non-vulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -771,9 +771,10 @@
       }
     },
     "node_modules/@octokit/core/node_modules/@octokit/request-error": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.0.tgz",
-      "integrity": "sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
         "deprecation": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "vitest": "^3.0.8"
   },
   "overrides": {
-    "esbuild": ">=0.25.0"
+    "esbuild": ">=0.25.0",
+    "@octokit/request-error@5.1.0": "5.1.1"
   }
 }


### PR DESCRIPTION
## Purpose

Overrides the `@octokit/request-error` dependency to a non-vulnerable version.

## Related Issues

https://github.com/github/dependency-submission-toolkit/security/dependabot/43
