### PR TITLE
Update version to 2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@github/dependency-submission-toolkit",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@github/dependency-submission-toolkit",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "MIT",
       "workspaces": [
         "example"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/dependency-submission-toolkit",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A TypeScript library for creating dependency snapshots.",
   "homepage": "https://github.com/github/dependency-submission-toolkit",
   "bugs": {


### PR DESCRIPTION
## Purpose

Preparing for a new release. All of the changes since 2.0.4 are dependency updates or non-code updates, so 2.0.5 is the most appropriate next version number.

## Related Issues

Closes a security finding.
