### PR TITLE
Add id to submitSnapshot success response

### DIFF
--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -189,7 +189,8 @@ export async function submitSnapshot(
     const result = response.data.result
     if (result === 'SUCCESS' || result === 'ACCEPTED') {
       core.notice(
-        `Snapshot successfully created at ${response.data.created_at.toString()}`
+        `Snapshot successfully created at ${response.data.created_at.toString()}` +
+          ` with id ${response.data.id}`
       )
     } else {
       core.error(


### PR DESCRIPTION
## Purpose

This change will add the Snapshot id returned by Dependency Graph when a Snapshot is successfully submitted.

The Snapshot id is useful information to have when troubleshooting Dependency Graph issues as it facilitates the correlation of workflow run (or job) with a particular Snapshot reported in Dependency Graph. 

It will also help GitHub Support Engineers to verify whether the canonical Snapshot reporting in our Internal Tooling matches the workflow run discussed in the support tickets.

The expected outcome is that the additional Snapshot Id will be written to workflow run log and summary when actions that leverage the dependency submission toolkit are used. For example, the [advanced-security/maven-dependency-submission-action](https://github.com/advanced-security/maven-dependency-submission-action) and [advanced-security/component-detection-dependency-submission-action](https://github.com/advanced-security/component-detection-dependency-submission-action) actions.

## Related Issues

_What issues does this PR close or relate to?_

N/A

---

- Confirmed that tests are passing locally.
- Triggered a workflow run with the `Example Dependency Submission Action` to confirm the desired output

![sample-updated-output-2](https://github.com/user-attachments/assets/c7e6a5b8-4814-447b-8f92-21e4d6db2524)
![sample-updated-output](https://github.com/user-attachments/assets/cd1a0534-809f-424d-9787-206d134a0a69)

