### PR TITLE
Upgrade Undici to 5.29.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2423,10 +2423,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-      "license": "MIT",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "overrides": {
     "esbuild": ">=0.25.0",
-    "@octokit/request-error@5.1.0": "5.1.1"
+    "@octokit/request-error@5.1.0": "5.1.1",
+    "undici": "5.29.0"
   }
 }


### PR DESCRIPTION
## Purpose

_Describe the purpose of this pull request_

Uses an override to upgrade Undici packages to a non-vulnerable version

## Related Issues

_What issues does this PR close or relate to?_

- Relates to: https://github.com/github/dependency-submission-toolkit/security/dependabot/53
