### PR TITLE
Configure npm publish workflow with provenance support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,4 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false --allow-same-version
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm publish --provenance
+      - run: npm publish --access public --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write # for provenance and publish access
 
 jobs:
   publish-npm:
@@ -22,6 +23,4 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false --allow-same-version
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_token }}
+      - run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
   id-token: write # for provenance and publish access
 
 jobs:


### PR DESCRIPTION
Updated publish workflow to include provenance and removed npm whoami step.

## Purpose

We required trusted publishing for npm packages using OIDC https://docs.npmjs.com/trusted-publishers. It's been configured in NPM and now we just need to enable it in the workflow

<img width="1230" height="393" alt="image" src="https://github.com/user-attachments/assets/37078ee1-51b4-4ce4-be68-f17cf50e0d42" />


## Related Issues

https://github.slack.com/archives/CMZ4DC9BL/p1776702563854929
